### PR TITLE
summernote 修正

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -11241,3 +11241,7 @@ body {
   font-size: 0.75rem;
   border-radius: 0.375rem !important;
 }
+
+.note-editor .open > .dropdown-menu {
+  display: block;
+}

--- a/resources/views/layouts/admin/footer.blade.php
+++ b/resources/views/layouts/admin/footer.blade.php
@@ -12,7 +12,7 @@
 </footer>
 
 <!-- template -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 <script src="{{asset('js/scripts.js')}}"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.min.js" crossorigin="anonymous"></script>
 <script src="{{asset('assets/demo/chart-area-demo.js')}}"></script>
@@ -25,9 +25,7 @@
 <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
 <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
 <!-- include summernote css/js -->
-<script src="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote.min.js"></script>
-
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-bs5.min.js"></script>
 
 <script>
     $(document).ready(function() {

--- a/resources/views/layouts/admin/header.blade.php
+++ b/resources/views/layouts/admin/header.blade.php
@@ -10,8 +10,5 @@
         <!-- datepicker -->
         <link rel="stylesheet" href="//code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
         <!-- summernote -->
-        <link href="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote.min.css" rel="stylesheet">
-
-        <link href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet">
-
+        <link href="https://cdn.jsdelivr.net/npm/summernote@0.8.20/dist/summernote-bs5.min.css" rel="stylesheet">
     </head>


### PR DESCRIPTION
summernote 가 이용하는 bootstrap이 구버전,
현재 이용하는 bootstrap이 신버전으로 css상의 충돌이 발견,
현 css에 summernote에 적용하는 css를 추가해줌